### PR TITLE
change: Language setting is now depend on OS setting at default.

### DIFF
--- a/BJD/option/OptionBasic.cs
+++ b/BJD/option/OptionBasic.cs
@@ -38,8 +38,8 @@ namespace Bjd.option {
             onePage.Add(new OneVal("serverName", "", Crlf.Nextline, new CtrlTextBox(IsJp() ? "サーバ名" : "Server Name", 20)));
             onePage.Add(new OneVal("editBrowse", false, Crlf.Nextline,
                                    new CtrlCheckBox(IsJp() ? "フォルダ・ファイル選択を編集にする" : "can edit browse control")));
-            onePage.Add(new OneVal("lang", 0, Crlf.Nextline,
-                                   new CtrlComboBox(IsJp() ? "言語" : "Language", new []{"Japanese", "English"}, 80)));
+            onePage.Add(new OneVal("lang", 2, Crlf.Nextline,
+                                   new CtrlComboBox(IsJp() ? "言語" : "Language", new []{"Japanese", "English", "Auto"}, 80)));
             return onePage;
         }
 

--- a/BJD/util/IniDb.cs
+++ b/BJD/util/IniDb.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Bjd.ctrl;
 using Bjd.option;
 
@@ -235,13 +236,20 @@ namespace Bjd.util{
         // 設定ファイルから"lang"の値を読み出す
         public bool IsJp(){
             var listVal = new ListVal{
-                new OneVal("lang", 0, Crlf.Nextline,
-                           new CtrlComboBox("Language", new[]{"Japanese", "English"}, 80))
+                new OneVal("lang", 2, Crlf.Nextline,
+                           new CtrlComboBox("Language", new[]{"Japanese", "English", "Auto"}, 80))
             };
             Read("Basic", listVal);
             var oneVal = listVal.Search("lang");
-            return ((int) oneVal.Value == 0);
-
+            var bjdLangId = (int)oneVal.Value;
+            if (bjdLangId == 2/*Auto*/)
+            {
+                return (Thread.CurrentThread.CurrentUICulture.Name == "ja-JP");
+            }
+            else
+            {
+                return (bjdLangId == 0);
+            }
         }
     }
 }


### PR DESCRIPTION
UIの言語設定(日本語か英語か)を、既定ではOS設定に従うようにしてみました。

Option.ini に保存される LIST=Basic\blang 値が 0(Japanese), 1(English) である点は変わらず、2 をAutoとし、 2のときに OS 設定に従って日本語とするかどうかを判断するようにしました。

Option.ini がないインストール直後の状態で、これまでは lang = 0(Japanse) でアプリを初期化 & Option.ini に書き出していたところが、2(Auto) で初期化 & Option.ini 出力されるように変わっております。

インストーラ版(.msi) が日本語UIしかないという点は残りますが、Zipアーカイブ版であれば、英語圏の方々にも追加の設定不要で英語UIで使っていただけるようになると思います。
